### PR TITLE
Fix base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/artefacts/ros2:humble-fortress-0.4.5
+FROM public.ecr.aws/artefacts/ros2:humble-fortress
 
 WORKDIR /ws
 


### PR DESCRIPTION
Removing the artefacts version pinning which was pointing to a deprecated version