### PR TITLE
Jazzy harmonic migration fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ source install/setup.bash
 
 ## Run example
 ```
-ros2 run nav2_gz_testing example_waypoint_follower.py
+ros2 launch nav2_gz_testing waypoint_follower_example_launch.py
 ```
 
 ## Run tests with **pytest** locally

--- a/src/nav2_gz_testing/package.xml
+++ b/src/nav2_gz_testing/package.xml
@@ -25,6 +25,8 @@
   <exec_depend>rqt_tf_tree</exec_depend>
   <exec_depend>navigation2</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
+  <!-- nav2_route needed because: https://github.com/ros-navigation/navigation2/issues/5634#issuecomment-3431532519 -->
+  <exec_depend>nav2_route</exec_depend>
   <exec_depend>tf2_tools</exec_depend>
   <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>image_transport</exec_depend>


### PR DESCRIPTION
Fix: 
 - Add the ros2 launch command to the readme that runs the full example. Previously, we only had a command there to run the controller node, which wouldn't bring up nav2, gazebo, etc. 
 - Add extra dependency for Nav2 not finding `route_server` service. More info: https://github.com/ros-navigation/navigation2/issues/5634#issuecomment-3431532519